### PR TITLE
feat: central gear catalog with reference-based lighterpack packs

### DIFF
--- a/_data/gear.yml
+++ b/_data/gear.yml
@@ -124,7 +124,7 @@ nitecore-nb10000:
   name: nb10000
   brand: NITECORE
   weight_mg: 150000
-  description: "NITCORE NB10000 Gen2; USB line"
+  description: "NITECORE NB10000 Gen2; USB line"
   category_hint: Device
 
 zenone-z1902:

--- a/_data/gear.yml
+++ b/_data/gear.yml
@@ -1,0 +1,142 @@
+# Central gear catalog — single source of truth for all gear items.
+# Each key is a unique slug used to reference the item from pack files.
+# Pack files in _data/lighterpack/ use `gear: <slug>` to reference items here.
+
+fuga-air13:
+  name: Run Vest AIR 13
+  brand: FUGA
+  weight_mg: 230000
+  description: "FUGA AIR13; 高频口哨"
+  category_hint: Cloth
+
+fuga-soft-flask:
+  name: Soft Flask
+  brand: FUGA
+  weight_mg: 38000
+  description: "FUGA"
+  category_hint: Cloth
+
+fuga-aero-light2:
+  name: AERO light2.0
+  brand: FUGA
+  weight_mg: 135000
+  description: "FUGA light2.0"
+  category_hint: Cloth
+
+fuga-ex330:
+  name: EX330
+  brand: FUGA
+  weight_mg: 570000
+  description: "FUGA"
+  category_hint: Cloth
+
+fuga-running-top:
+  name: Running Top
+  brand: FUGA
+  weight_mg: 180000
+  description: "FUGA Crew-neck Top"
+  category_hint: Cloth
+
+space-blanket:
+  name: Space Blanket
+  weight_mg: 55000
+  description: ""
+  category_hint: Cloth
+
+outopia-short-tights:
+  name: Short Tights
+  brand: Outopia
+  weight_mg: 155000
+  description: "Outopia Men's Soul Run Short Tights 2.5L"
+  category_hint: Cloth
+
+outopia-running-cap:
+  name: Running Cap
+  brand: Outopia
+  weight_mg: 45000
+  description: "Outopia Unisex's Wild Hat Running Cap"
+  category_hint: Cloth
+
+injinji-mini-crew-toesocks:
+  name: Mini Crew Toesocks
+  brand: Injinji
+  weight_mg: 42000
+  description: "Injinji Run Lightweight Mini Crew Unisex Toesocks"
+  category_hint: Cloth
+
+ud-race-belt-5:
+  name: Race Belt 5.0
+  brand: Ultimate Direction
+  weight_mg: 71000
+  description: "Ultimate Direction"
+  category_hint: Cloth
+
+deeplant-electrolyte:
+  name: Deeplant
+  brand: Deeplant
+  weight_mg: 27000
+  description: "电解质液"
+  category_hint: Eat
+
+sis-go-isotonic:
+  name: Go Isotonic
+  brand: SiS
+  weight_mg: 66000
+  description: "Sis 等渗"
+  category_hint: Eat
+
+sis-beta-fuel:
+  name: Beta Fuel
+  brand: SiS
+  weight_mg: 66000
+  description: "Sis 黑胶"
+  category_hint: Eat
+
+maisheng-energy-cruiser:
+  name: Energy Cruiser
+  brand: 迈胜
+  weight_mg: 60000
+  description: "迈胜黑胶"
+  category_hint: Eat
+
+huawei-mate70:
+  name: mate70
+  brand: Huawei
+  weight_mg: 203000
+  description: "Huawei"
+  category_hint: Device
+
+coros-vertix-2s:
+  name: vertix 2s
+  brand: COROS
+  weight_mg: 87000
+  description: "coros"
+  category_hint: Device
+
+fenix-hl18r:
+  name: HL18R
+  brand: FENIX
+  weight_mg: 91000
+  description: "FENIX HL18R-T v2.0"
+  category_hint: Device
+
+nitecore-nb10000:
+  name: nb10000
+  brand: NITECORE
+  weight_mg: 150000
+  description: "NITCORE NB10000 Gen2; USB line"
+  category_hint: Device
+
+zenone-z1902:
+  name: Z1902
+  brand: ZENONE
+  weight_mg: 113000
+  description: "ZENONE 120cm"
+  category_hint: Device
+
+huawei-freeclip2:
+  name: FreeClip2
+  brand: Huawei
+  weight_mg: 48000
+  description: "Huawei"
+  category_hint: Device

--- a/_data/lighterpack/4nz20u.yml
+++ b/_data/lighterpack/4nz20u.yml
@@ -24,95 +24,25 @@ categories:
     display: 1.56 kg
   item_count: 11
   items:
-  - name: Run Vest AIR 13
-    description: FUGA AIR13; 高频口哨
-    weight:
-      mg: 230000
-      grams: 230.0
-      value: '230'
-      unit: g
-      display: 230 g
+  - gear: fuga-air13
     quantity: 1
-  - name: Soft Flask
-    description: FUGA
-    weight:
-      mg: 38000
-      grams: 38.0
-      value: '38'
-      unit: g
-      display: 38 g
+  - gear: fuga-soft-flask
     quantity: 2
-  - name: AERO light2.0
-    description: FUGA light2.0
-    weight:
-      mg: 135000
-      grams: 135.0
-      value: '135'
-      unit: g
-      display: 135 g
+  - gear: fuga-aero-light2
     quantity: 1
-  - name: EX330
-    description: FUGA
-    weight:
-      mg: 570000
-      grams: 570.0
-      value: '570'
-      unit: g
-      display: 570 g
+  - gear: fuga-ex330
     quantity: 1
-  - name: Running Top
-    description: FUGA Crew-neck Top
-    weight:
-      mg: 180000
-      grams: 180.0
-      value: '180'
-      unit: g
-      display: 180 g
+  - gear: fuga-running-top
     quantity: 1
-  - name: Space Blanket
-    description: ''
-    weight:
-      mg: 55000
-      grams: 55.0
-      value: '55'
-      unit: g
-      display: 55 g
+  - gear: space-blanket
     quantity: 1
-  - name: Short Tights
-    description: Outopia Men's Soul Run Short Tights 2.5L
-    weight:
-      mg: 155000
-      grams: 155.0
-      value: '155'
-      unit: g
-      display: 155 g
+  - gear: outopia-short-tights
     quantity: 1
-  - name: Running Cap
-    description: Outopia Unisex's Wild Hat Running Cap
-    weight:
-      mg: 45000
-      grams: 45.0
-      value: '45'
-      unit: g
-      display: 45 g
+  - gear: outopia-running-cap
     quantity: 1
-  - name: Mini Crew Toesocks
-    description: Injinji Run Lightweight Mini Crew Unisex Toesocks
-    weight:
-      mg: 42000
-      grams: 42.0
-      value: '42'
-      unit: g
-      display: 42 g
+  - gear: injinji-mini-crew-toesocks
     quantity: 1
-  - name: Race Belt 5.0
-    description: Ultimate Direction
-    weight:
-      mg: 71000
-      grams: 71.0
-      value: '71'
-      unit: g
-      display: 71 g
+  - gear: ud-race-belt-5
     quantity: 1
 - id: '47'
   name: Eat
@@ -125,41 +55,13 @@ categories:
     display: 1.11 kg
   item_count: 24
   items:
-  - name: Deeplant
-    description: 电解质液
-    weight:
-      mg: 27000
-      grams: 27.0
-      value: '27'
-      unit: g
-      display: 27 g
+  - gear: deeplant-electrolyte
     quantity: 12
-  - name: Go Isotonic
-    description: Sis 等渗
-    weight:
-      mg: 66000
-      grams: 66.0
-      value: '66'
-      unit: g
-      display: 66 g
+  - gear: sis-go-isotonic
     quantity: 4
-  - name: Beta Fuel
-    description: Sis 黑胶
-    weight:
-      mg: 66000
-      grams: 66.0
-      value: '66'
-      unit: g
-      display: 66 g
+  - gear: sis-beta-fuel
     quantity: 7
-  - name: Energy Cruiser
-    description: 迈胜黑胶
-    weight:
-      mg: 60000
-      grams: 60.0
-      value: '60'
-      unit: g
-      display: 60 g
+  - gear: maisheng-energy-cruiser
     quantity: 1
 - id: '51'
   name: Device
@@ -172,57 +74,15 @@ categories:
     display: 0.81 kg
   item_count: 7
   items:
-  - name: mate70
-    description: Huawei
-    weight:
-      mg: 203000
-      grams: 203.0
-      value: '203'
-      unit: g
-      display: 203 g
+  - gear: huawei-mate70
     quantity: 1
-  - name: vertix 2s
-    description: coros
-    weight:
-      mg: 87000
-      grams: 87.0
-      value: '87'
-      unit: g
-      display: 87 g
+  - gear: coros-vertix-2s
     quantity: 1
-  - name: HL18R
-    description: FENIX HL18R-T v2.0
-    weight:
-      mg: 91000
-      grams: 91.0
-      value: '91'
-      unit: g
-      display: 91 g
+  - gear: fenix-hl18r
     quantity: 1
-  - name: nb10000
-    description: NITCORE NB10000 Gen2; USB line
-    weight:
-      mg: 150000
-      grams: 150.0
-      value: '150'
-      unit: g
-      display: 150 g
+  - gear: nitecore-nb10000
     quantity: 1
-  - name: Z1902
-    description: ZENONE 120cm
-    weight:
-      mg: 113000
-      grams: 113.0
-      value: '113'
-      unit: g
-      display: 113 g
+  - gear: zenone-z1902
     quantity: 2
-  - name: FreeClip2
-    description: Huawei
-    weight:
-      mg: 48000
-      grams: 48.0
-      value: '48'
-      unit: g
-      display: 48 g
+  - gear: huawei-freeclip2
     quantity: 1

--- a/_includes/gear_usage.html
+++ b/_includes/gear_usage.html
@@ -1,0 +1,50 @@
+{% comment %}
+  Gear usage reverse index.
+  For each gear item, find all packs that reference it.
+  Usage: {% include gear_usage.html slug="fuga-air13" %}
+{% endcomment %}
+
+{% assign target_slug = include.slug %}
+{% assign used_in = "" %}
+
+{% for pack_entry in site.data.lighterpack %}
+  {% assign pack = pack_entry[1] %}
+  {% for category in pack.categories %}
+    {% for item in category.items %}
+      {% if item.gear == target_slug %}
+        {% if used_in != "" %}
+          {% assign used_in = used_in | append: "|" %}
+        {% endif %}
+        {% assign used_in = used_in | append: pack.title | append: "::" | append: pack.id %}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+{% endfor %}
+
+{% if used_in != "" %}
+<ul class="gear-usage-list">
+  {% assign packs = used_in | split: "|" %}
+  {% for pack_info in packs %}
+    {% assign parts = pack_info | split: "::" %}
+    {% assign pack_title = parts[0] %}
+    {% assign pack_id = parts[1] %}
+    {% comment %} Find the post that uses this pack {% endcomment %}
+    {% assign found_post = nil %}
+    {% for post in site.posts %}
+      {% if post.content contains pack_id %}
+        {% assign found_post = post %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+    <li>
+      {% if found_post %}
+        <a href="{{ found_post.url | relative_url }}">{{ pack_title }}</a>
+      {% else %}
+        {{ pack_title }}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p class="gear-usage-none">尚未在任何活动中使用。</p>
+{% endif %}

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -26,33 +26,27 @@
     </div>
 
     <div class="lighterpack-summary-table-wrap">
-      <table class="lighterpack-summary-table">
-        <thead>
-          <tr>
-            <th aria-hidden="true"></th>
-            <th>Category</th>
-            <th>Weight</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for category in pack.categories %}
-          <tr>
-            <td>
-              <span class="lighterpack-dot" style="background-color: {{ category.color }};"></span>
-            </td>
-            <td>{{ category.name }}</td>
-            <td>{{ category.weight.display }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-        <tfoot>
-          <tr>
-            <td></td>
-            <td>Total</td>
-            <td>{{ pack.total.display }}</td>
-          </tr>
-        </tfoot>
-      </table>
+      <ul class="lighterpack-totals">
+        <li class="lighterpack-totals-header">
+          <span class="lighterpack-totals-cell">&nbsp;</span>
+          <span class="lighterpack-totals-cell">Category</span>
+          <span class="lighterpack-totals-cell">Weight</span>
+        </li>
+        {% for category in pack.categories %}
+        <li class="lighterpack-totals-row">
+          <span class="lighterpack-totals-cell lighterpack-totals-legend-cell">
+            <span class="lighterpack-legend" style="background-color: {{ category.color }};"></span>
+          </span>
+          <span class="lighterpack-totals-cell">{{ category.name }}</span>
+          <span class="lighterpack-totals-cell lighterpack-number">{{ category.weight.display }}</span>
+        </li>
+        {% endfor %}
+        <li class="lighterpack-totals-footer">
+          <span class="lighterpack-totals-cell"></span>
+          <span class="lighterpack-totals-cell lighterpack-subtotal" title="{{ pack.total.item_count }} items">Total</span>
+          <span class="lighterpack-totals-cell lighterpack-number lighterpack-subtotal">{{ pack.total.display }}</span>
+        </li>
+      </ul>
     </div>
   </div>
 
@@ -61,7 +55,7 @@
     <section class="lighterpack-category">
       <ul class="lighterpack-items">
         <li class="lighterpack-items-header">
-          <h3 class="lighterpack-category-name">{{ category.name }}</h3>
+          <h2 class="lighterpack-category-name">{{ category.name }}</h2>
           <span class="lighterpack-col-weight">Weight</span>
           <span class="lighterpack-col-qty">qty</span>
         </li>
@@ -69,20 +63,20 @@
         {% for item in category.items %}
         <li class="lighterpack-item{% if item.worn %} lighterpack-item-worn{% endif %}{% if item.consumable %} lighterpack-item-consumable{% endif %}{% if item.star %} lighterpack-item-star{% endif %}">
           <span class="lighterpack-item-name">{{ item.name }}</span>
-          {% if item.description != '' %}<span class="lighterpack-item-description">{{ item.description }}</span>{% endif %}
+          <span class="lighterpack-item-description">{% if item.description != '' %}{{ item.description }}{% endif %}</span>
           <span class="lighterpack-item-actions">
             {% if item.worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
             {% if item.consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
             {% if item.star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
           </span>
-          <span class="lighterpack-item-weight">{{ item.weight.display }}</span>
-          <span class="lighterpack-item-qty" data-qty="{{ item.quantity }}">{{ item.quantity }}</span>
+          <span class="lighterpack-item-weight lighterpack-number">{{ item.weight.display }}</span>
+          <span class="lighterpack-item-qty lighterpack-number" data-qty="{{ item.quantity }}">{{ item.quantity }}</span>
         </li>
         {% endfor %}
 
         <li class="lighterpack-items-footer">
-          <span class="lighterpack-subtotal-weight">{{ category.weight.display }}</span>
-          <span class="lighterpack-subtotal-qty">{{ category.item_count }}</span>
+          <span class="lighterpack-subtotal-weight lighterpack-number"><div class="lighterpack-subtotal">{{ category.weight.display }}</div></span>
+          <span class="lighterpack-subtotal-qty lighterpack-number"><div class="lighterpack-subtotal">{{ category.item_count }}</div></span>
         </li>
       </ul>
     </section>

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -69,14 +69,14 @@
         {% for item in category.items %}
         <li class="lighterpack-item{% if item.worn %} lighterpack-item-worn{% endif %}{% if item.consumable %} lighterpack-item-consumable{% endif %}{% if item.star %} lighterpack-item-star{% endif %}">
           <span class="lighterpack-item-name">{{ item.name }}</span>
-          <span class="lighterpack-item-description">{{ item.description }}</span>
+          {% if item.description != '' %}<span class="lighterpack-item-description">{{ item.description }}</span>{% endif %}
           <span class="lighterpack-item-actions">
             {% if item.worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
             {% if item.consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
             {% if item.star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
           </span>
           <span class="lighterpack-item-weight">{{ item.weight.display }}</span>
-          <span class="lighterpack-item-qty">{{ item.quantity }}</span>
+          <span class="lighterpack-item-qty" data-qty="{{ item.quantity }}">{{ item.quantity }}</span>
         </li>
         {% endfor %}
 

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -61,41 +61,28 @@
         </li>
 
         {% for item in category.items %}
-        {% comment %} Resolve gear reference: if item.gear exists, merge from _data/gear.yml {% endcomment %}
-        {% if item.gear %}
-          {% assign gear_entry = site.data.gear[item.gear] %}
-          {% assign resolved_name = item.name | default: gear_entry.name %}
-          {% assign resolved_description = item.description | default: gear_entry.description %}
-          {% if item.weight %}
-            {% assign resolved_weight_display = item.weight.display %}
-          {% else %}
-            {% assign weight_mg = gear_entry.weight_mg %}
-            {% if weight_mg >= 1000000 %}
-              {% assign weight_val = weight_mg | divided_by: 1000000.0 %}
-              {% assign resolved_weight_display = weight_val | append: " kg" %}
-            {% else %}
-              {% assign weight_val = weight_mg | divided_by: 1000 %}
-              {% assign resolved_weight_display = weight_val | append: " g" %}
-            {% endif %}
-          {% endif %}
-          {% assign resolved_worn = item.worn %}
-          {% assign resolved_consumable = item.consumable %}
-          {% assign resolved_star = item.star %}
-        {% else %}
-          {% assign resolved_name = item.name %}
-          {% assign resolved_description = item.description %}
+        {% assign gear_entry = site.data.gear[item.gear] %}
+        {% assign resolved_name = item.name | default: gear_entry.name %}
+        {% assign resolved_description = item.description | default: gear_entry.description %}
+        {% if item.weight %}
           {% assign resolved_weight_display = item.weight.display %}
-          {% assign resolved_worn = item.worn %}
-          {% assign resolved_consumable = item.consumable %}
-          {% assign resolved_star = item.star %}
+        {% else %}
+          {% assign weight_mg = gear_entry.weight_mg %}
+          {% if weight_mg >= 1000000 %}
+            {% assign weight_val = weight_mg | divided_by: 1000000.0 %}
+            {% assign resolved_weight_display = weight_val | append: " kg" %}
+          {% else %}
+            {% assign weight_val = weight_mg | divided_by: 1000 %}
+            {% assign resolved_weight_display = weight_val | append: " g" %}
+          {% endif %}
         {% endif %}
-        <li class="lighterpack-item{% if resolved_worn %} lighterpack-item-worn{% endif %}{% if resolved_consumable %} lighterpack-item-consumable{% endif %}{% if resolved_star %} lighterpack-item-star{% endif %}">
+        <li class="lighterpack-item{% if item.worn %} lighterpack-item-worn{% endif %}{% if item.consumable %} lighterpack-item-consumable{% endif %}{% if item.star %} lighterpack-item-star{% endif %}">
           <span class="lighterpack-item-name">{{ resolved_name }}</span>
           <span class="lighterpack-item-description">{% if resolved_description != '' %}{{ resolved_description }}{% endif %}</span>
           <span class="lighterpack-item-actions">
-            {% if resolved_worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
-            {% if resolved_consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
-            {% if resolved_star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
+            {% if item.worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
+            {% if item.consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
+            {% if item.star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
           </span>
           <span class="lighterpack-item-weight lighterpack-number">{{ resolved_weight_display }}</span>
           <span class="lighterpack-item-qty lighterpack-number" data-qty="{{ item.quantity }}">{{ item.quantity }}</span>

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -59,46 +59,32 @@
   <div class="lighterpack-categories">
     {% for category in pack.categories %}
     <section class="lighterpack-category">
-      <div class="lighterpack-category-header">
-        <div class="lighterpack-category-name">
-          <span class="lighterpack-dot" style="background-color: {{ category.color }};"></span>
-          <h3>{{ category.name }}</h3>
-        </div>
-        <div class="lighterpack-category-total">{{ category.weight.display }}</div>
-      </div>
+      <ul class="lighterpack-items">
+        <li class="lighterpack-items-header">
+          <h3 class="lighterpack-category-name">{{ category.name }}</h3>
+          <span class="lighterpack-col-weight">Weight</span>
+          <span class="lighterpack-col-qty">qty</span>
+        </li>
 
-      <div class="lighterpack-table-wrap">
-        <table class="lighterpack-items-table">
-          <thead>
-            <tr>
-              <th>Item</th>
-              <th>Weight</th>
-              <th>qty</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for item in category.items %}
-            <tr>
-              <td>
-                <div class="lighterpack-item-name">{{ item.name }}</div>
-                {% if item.description != '' %}
-                <div class="lighterpack-item-description">{{ item.description }}</div>
-                {% endif %}
-              </td>
-              <td>{{ item.weight.display }}</td>
-              <td>{{ item.quantity }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td>{{ category.name }}</td>
-              <td>{{ category.weight.display }}</td>
-              <td>{{ category.item_count }}</td>
-            </tr>
-          </tfoot>
-        </table>
-      </div>
+        {% for item in category.items %}
+        <li class="lighterpack-item{% if item.worn %} lighterpack-item-worn{% endif %}{% if item.consumable %} lighterpack-item-consumable{% endif %}{% if item.star %} lighterpack-item-star{% endif %}">
+          <span class="lighterpack-item-name">{{ item.name }}</span>
+          <span class="lighterpack-item-description">{{ item.description }}</span>
+          <span class="lighterpack-item-actions">
+            {% if item.worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
+            {% if item.consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
+            {% if item.star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
+          </span>
+          <span class="lighterpack-item-weight">{{ item.weight.display }}</span>
+          <span class="lighterpack-item-qty">{{ item.quantity }}</span>
+        </li>
+        {% endfor %}
+
+        <li class="lighterpack-items-footer">
+          <span class="lighterpack-subtotal-weight">{{ category.weight.display }}</span>
+          <span class="lighterpack-subtotal-qty">{{ category.item_count }}</span>
+        </li>
+      </ul>
     </section>
     {% endfor %}
   </div>

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -61,15 +61,43 @@
         </li>
 
         {% for item in category.items %}
-        <li class="lighterpack-item{% if item.worn %} lighterpack-item-worn{% endif %}{% if item.consumable %} lighterpack-item-consumable{% endif %}{% if item.star %} lighterpack-item-star{% endif %}">
-          <span class="lighterpack-item-name">{{ item.name }}</span>
-          <span class="lighterpack-item-description">{% if item.description != '' %}{{ item.description }}{% endif %}</span>
+        {% comment %} Resolve gear reference: if item.gear exists, merge from _data/gear.yml {% endcomment %}
+        {% if item.gear %}
+          {% assign gear_entry = site.data.gear[item.gear] %}
+          {% assign resolved_name = item.name | default: gear_entry.name %}
+          {% assign resolved_description = item.description | default: gear_entry.description %}
+          {% if item.weight %}
+            {% assign resolved_weight_display = item.weight.display %}
+          {% else %}
+            {% assign weight_mg = gear_entry.weight_mg %}
+            {% if weight_mg >= 1000000 %}
+              {% assign weight_val = weight_mg | divided_by: 1000000.0 %}
+              {% assign resolved_weight_display = weight_val | append: " kg" %}
+            {% else %}
+              {% assign weight_val = weight_mg | divided_by: 1000 %}
+              {% assign resolved_weight_display = weight_val | append: " g" %}
+            {% endif %}
+          {% endif %}
+          {% assign resolved_worn = item.worn %}
+          {% assign resolved_consumable = item.consumable %}
+          {% assign resolved_star = item.star %}
+        {% else %}
+          {% assign resolved_name = item.name %}
+          {% assign resolved_description = item.description %}
+          {% assign resolved_weight_display = item.weight.display %}
+          {% assign resolved_worn = item.worn %}
+          {% assign resolved_consumable = item.consumable %}
+          {% assign resolved_star = item.star %}
+        {% endif %}
+        <li class="lighterpack-item{% if resolved_worn %} lighterpack-item-worn{% endif %}{% if resolved_consumable %} lighterpack-item-consumable{% endif %}{% if resolved_star %} lighterpack-item-star{% endif %}">
+          <span class="lighterpack-item-name">{{ resolved_name }}</span>
+          <span class="lighterpack-item-description">{% if resolved_description != '' %}{{ resolved_description }}{% endif %}</span>
           <span class="lighterpack-item-actions">
-            {% if item.worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
-            {% if item.consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
-            {% if item.star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
+            {% if resolved_worn %}<i class="lighterpack-icon lighterpack-icon-worn" title="Worn weight">👕</i>{% endif %}
+            {% if resolved_consumable %}<i class="lighterpack-icon lighterpack-icon-consumable" title="Consumable">💧</i>{% endif %}
+            {% if resolved_star %}<i class="lighterpack-icon lighterpack-icon-star" title="Starred">⭐</i>{% endif %}
           </span>
-          <span class="lighterpack-item-weight lighterpack-number">{{ item.weight.display }}</span>
+          <span class="lighterpack-item-weight lighterpack-number">{{ resolved_weight_display }}</span>
           <span class="lighterpack-item-qty lighterpack-number" data-qty="{{ item.quantity }}">{{ item.quantity }}</span>
         </li>
         {% endfor %}

--- a/_includes/lighterpack.html
+++ b/_includes/lighterpack.html
@@ -75,8 +75,8 @@
         {% endfor %}
 
         <li class="lighterpack-items-footer">
-          <span class="lighterpack-subtotal-weight lighterpack-number"><div class="lighterpack-subtotal">{{ category.weight.display }}</div></span>
-          <span class="lighterpack-subtotal-qty lighterpack-number"><div class="lighterpack-subtotal">{{ category.item_count }}</div></span>
+          <span class="lighterpack-subtotal-weight lighterpack-number lighterpack-subtotal">{{ category.weight.display }}</span>
+          <span class="lighterpack-subtotal-qty lighterpack-number lighterpack-subtotal">{{ category.item_count }}</span>
         </li>
       </ul>
     </section>

--- a/_tabs/gear.md
+++ b/_tabs/gear.md
@@ -1,0 +1,24 @@
+---
+layout: page
+icon: fas fa-backpack
+order: 6
+title: Gear
+---
+
+装备库：所有装备在这里只定义一次，不同活动通过引用来复用。
+
+{% for entry in site.data.gear %}
+  {% assign slug = entry[0] %}
+  {% assign gear = entry[1] %}
+
+### {{ gear.name }}
+
+{% if gear.brand %} **品牌** {{ gear.brand }} · {% endif %}**重量** {% if gear.weight_mg >= 1000000 %}{{ gear.weight_mg | divided_by: 1000000.0 }} kg{% else %}{{ gear.weight_mg | divided_by: 1000 }} g{% endif %} {% if gear.description != '' and gear.description %} · {{ gear.description }}{% endif %}
+
+**使用记录：**
+
+{% include gear_usage.html slug=slug %}
+
+---
+
+{% endfor %}

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -29,6 +29,8 @@ pre,
   font-family: var(--font-mono-zh);
 }
 
+/* ── LighterPack embed ── */
+/* Font & base: matches LP _common.scss */
 .lighterpack-embed {
   margin: 2rem 0;
   border: 1px solid rgba(148, 163, 184, 0.26);
@@ -36,6 +38,27 @@ pre,
   background: var(--card-bg, #fff);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
   overflow: hidden;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 13px;
+  line-height: 1.3;
+  color: #282828;
+  box-sizing: border-box;
+}
+
+.lighterpack-embed *,
+.lighterpack-embed *::before,
+.lighterpack-embed *::after {
+  box-sizing: inherit;
+}
+
+.lighterpack-number {
+  text-align: right;
+}
+
+.lighterpack-subtotal {
+  text-align: right;
+  white-space: nowrap;
+  font-weight: 600;
 }
 
 .lighterpack-header {
@@ -52,10 +75,11 @@ pre,
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  color: var(--text-muted-color, #64748b);
+  color: #666;
   font-size: 0.92rem;
 }
 
+/* ── Summary section (chart + totals) ── */
 .lighterpack-summary {
   display: flex;
   flex-wrap: wrap;
@@ -101,7 +125,7 @@ pre,
 
 .lighterpack-total-label,
 .lighterpack-total-items {
-  color: var(--text-muted-color, #64748b);
+  color: #666;
   font-size: 0.92rem;
 }
 
@@ -111,54 +135,77 @@ pre,
   line-height: 1.2;
 }
 
+/* ── Totals table (LP uses display:table via .lpTable/.lpRow/.lpCell) ── */
 .lighterpack-summary-table-wrap {
   flex: 1 1 340px;
 }
 
-.lighterpack-summary-table {
+.lighterpack-totals {
+  display: table;
   width: 100%;
-  border-collapse: collapse;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.lighterpack-summary-table th,
-.lighterpack-summary-table td {
-  padding: 0.7rem 0.8rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-  vertical-align: top;
+.lighterpack-totals-header,
+.lighterpack-totals-row,
+.lighterpack-totals-footer {
+  display: table-row;
 }
 
-.lighterpack-summary-table thead th {
-  color: var(--text-muted-color, #64748b);
-  font-size: 0.88rem;
-  font-weight: 600;
-  text-transform: none;
-}
-
-.lighterpack-summary-table td:last-child,
-.lighterpack-summary-table th:last-child {
-  text-align: right;
-  white-space: nowrap;
-}
-
-.lighterpack-summary-table tfoot td {
-  font-weight: 700;
-  border-bottom: 0;
-}
-
-.lighterpack-dot {
-  display: inline-block;
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 999px;
+.lighterpack-totals-cell {
+  display: table-cell;
+  border-top: 1px dotted #aaa;
+  padding: 1px 8px;
   vertical-align: middle;
 }
 
+.lighterpack-totals-cell:first-child {
+  padding-left: 0;
+}
+
+.lighterpack-totals-cell:last-child {
+  padding-right: 0;
+}
+
+.lighterpack-totals-header .lighterpack-totals-cell {
+  border-top: none;
+  border-bottom: 1px solid #aaa;
+  font-weight: 600;
+  vertical-align: bottom;
+}
+
+.lighterpack-totals-header + .lighterpack-totals-row .lighterpack-totals-cell {
+  border-top: none;
+}
+
+.lighterpack-totals-footer .lighterpack-totals-cell {
+  border-top: 1px solid #aaa;
+  font-weight: 600;
+}
+
+.lighterpack-totals-legend-cell {
+  width: 12px;
+}
+
+/* LP legend: 10x10 square with white border */
+.lighterpack-legend {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border: 1px solid #fff;
+}
+
+/* ── Category items (LP flex layout) ── */
 .lighterpack-categories {
   border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .lighterpack-category {
   padding: 0;
+  list-style: none;
+  margin: 0 0 20px;
 }
 
 .lighterpack-category + .lighterpack-category {
@@ -178,35 +225,35 @@ pre,
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 0.45rem 1.5rem;
-  border-top: 1px dotted rgba(148, 163, 184, 0.35);
+  border-top: 1px dotted #aaa;
+  padding: 1px 20px;
 }
 
 .lighterpack-items-header {
   border-top: none;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  padding-top: 1rem;
-  padding-bottom: 0.45rem;
+  border-bottom: 1px solid #aaa;
+  height: 31px;
   align-items: flex-end;
 }
 
 .lighterpack-items-footer {
-  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  border-top-style: solid;
   justify-content: flex-end;
-  padding-top: 0.55rem;
-  padding-bottom: 0.8rem;
 }
 
+/* LP share: h2.lpCategoryName { font-size:18px; margin:0 } */
 .lighterpack-category-name {
   flex: 1 1 auto;
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 18px;
+  font-weight: 600;
 }
 
+/* Header column labels: LP .lpHeader { text-align: center } */
 .lighterpack-col-weight,
 .lighterpack-col-qty {
-  color: var(--text-muted-color, #64748b);
-  font-size: 0.88rem;
+  color: #666;
+  font-size: 13px;
   text-align: center;
 }
 
@@ -218,10 +265,10 @@ pre,
   flex: 0 0 60px;
 }
 
+/* Item row cells: match LP flex values exactly */
 .lighterpack-item-name {
   flex: 1 1 150px;
   min-width: 50px;
-  font-weight: 600;
   margin-right: 4px;
 }
 
@@ -229,53 +276,46 @@ pre,
   flex: 2 0 200px;
   min-width: 100px;
   margin-right: 4px;
-  color: var(--text-muted-color, #64748b);
-  font-size: 0.94rem;
+  color: #666;
 }
 
+/* LP share: .lpActionsCell { flex-basis: 75px } */
 .lighterpack-item-actions {
   flex: 0 0 75px;
   text-align: right;
-  padding: 0 0.5rem;
+  padding: 0 10px;
 }
 
 .lighterpack-icon {
   font-style: normal;
-  margin-right: 4px;
+  margin-right: 8px;
   font-size: 0.85rem;
+  opacity: 1;
 }
 
+/* LP: .lpWeightCell { flex: 0 0 110px } + .lpNumber { text-align: right } */
 .lighterpack-item-weight {
   flex: 0 0 110px;
-  text-align: right;
-  white-space: nowrap;
 }
 
+/* LP: .lpQtyCell { flex: 0 0 60px } + .lpNumber { text-align: right } */
 .lighterpack-item-qty {
   flex: 0 0 60px;
-  text-align: center;
 }
 
+/* Footer subtotals */
 .lighterpack-subtotal-weight {
   flex: 0 0 110px;
-  text-align: right;
-  white-space: nowrap;
-  font-weight: 700;
 }
 
 .lighterpack-subtotal-qty {
   flex: 0 0 60px;
-  text-align: center;
-  font-weight: 700;
 }
 
-@media (max-width: 768px) {
-  .lighterpack-summary,
-  .lighterpack-items-header,
-  .lighterpack-item,
-  .lighterpack-items-footer {
-    padding-left: 1.1rem;
-    padding-right: 1.1rem;
+/* ── Mobile: LP uses 720px breakpoint ── */
+@media only screen and (max-width: 720px) {
+  .lighterpack-summary {
+    padding: 1.1rem;
   }
 
   .lighterpack-chart-shell {
@@ -287,31 +327,25 @@ pre,
     gap: 0.25rem;
   }
 
+  .lighterpack-items-header,
+  .lighterpack-item,
+  .lighterpack-items-footer {
+    padding-left: 1.1rem;
+    padding-right: 1.1rem;
+  }
+
   .lighterpack-item {
     flex-wrap: wrap;
     align-items: baseline;
     justify-content: flex-end;
+    padding-top: 3px;
+    padding-bottom: 3px;
   }
 
   .lighterpack-item-name {
     flex-basis: 90px;
+    font-weight: bold;
     order: 2;
-  }
-
-  .lighterpack-item-description {
-    flex-basis: calc(100% - 50px);
-    order: 98;
-  }
-
-  .lighterpack-item-actions {
-    flex: 0 0 auto;
-    order: 99;
-    padding: 0 0.5rem;
-  }
-
-  .lighterpack-item-weight {
-    flex-basis: 100px;
-    order: 5;
   }
 
   .lighterpack-item-qty {
@@ -323,6 +357,23 @@ pre,
     display: none;
   }
 
+  .lighterpack-item-weight {
+    flex-basis: 100px;
+    order: 5;
+  }
+
+  .lighterpack-item-description {
+    flex-basis: calc(100% - 50px);
+    order: 98;
+  }
+
+  .lighterpack-item-actions {
+    flex: 0 0 auto;
+    order: 99;
+    padding: 0 10px;
+    text-align: right;
+  }
+
   .lighterpack-items-header {
     .lighterpack-col-weight,
     .lighterpack-col-qty {
@@ -332,5 +383,15 @@ pre,
 
   .lighterpack-items-footer .lighterpack-subtotal-qty {
     display: none;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .lighterpack-summary {
+    flex-direction: column;
+  }
+
+  .lighterpack-chart-shell {
+    max-width: 200px;
   }
 }

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -115,23 +115,19 @@ pre,
   flex: 1 1 340px;
 }
 
-.lighterpack-summary-table,
-.lighterpack-items-table {
+.lighterpack-summary-table {
   width: 100%;
   border-collapse: collapse;
 }
 
 .lighterpack-summary-table th,
-.lighterpack-summary-table td,
-.lighterpack-items-table th,
-.lighterpack-items-table td {
+.lighterpack-summary-table td {
   padding: 0.7rem 0.8rem;
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
   vertical-align: top;
 }
 
-.lighterpack-summary-table thead th,
-.lighterpack-items-table thead th {
+.lighterpack-summary-table thead th {
   color: var(--text-muted-color, #64748b);
   font-size: 0.88rem;
   font-weight: 600;
@@ -139,17 +135,12 @@ pre,
 }
 
 .lighterpack-summary-table td:last-child,
-.lighterpack-summary-table th:last-child,
-.lighterpack-items-table td:nth-child(2),
-.lighterpack-items-table td:nth-child(3),
-.lighterpack-items-table th:nth-child(2),
-.lighterpack-items-table th:nth-child(3) {
+.lighterpack-summary-table th:last-child {
   text-align: right;
   white-space: nowrap;
 }
 
-.lighterpack-summary-table tfoot td,
-.lighterpack-items-table tfoot td {
+.lighterpack-summary-table tfoot td {
   font-weight: 700;
   border-bottom: 0;
 }
@@ -167,55 +158,124 @@ pre,
 }
 
 .lighterpack-category {
-  padding: 1.25rem 1.5rem 1.5rem;
+  padding: 0;
 }
 
 .lighterpack-category + .lighterpack-category {
   border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
-.lighterpack-category-header {
+.lighterpack-items {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  width: 100%;
+}
+
+.lighterpack-items-header,
+.lighterpack-item,
+.lighterpack-items-footer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.9rem;
+  padding: 0.45rem 1.5rem;
+  border-top: 1px dotted rgba(148, 163, 184, 0.35);
+}
+
+.lighterpack-items-header {
+  border-top: none;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  padding-top: 1rem;
+  padding-bottom: 0.45rem;
+  align-items: flex-end;
+}
+
+.lighterpack-items-footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  justify-content: flex-end;
+  padding-top: 0.55rem;
+  padding-bottom: 0.8rem;
 }
 
 .lighterpack-category-name {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-}
-
-.lighterpack-category-name h3,
-.lighterpack-category-total {
+  flex: 1 1 auto;
   margin: 0;
+  font-size: 1.1rem;
 }
 
-.lighterpack-category-total {
-  font-weight: 700;
+.lighterpack-col-weight,
+.lighterpack-col-qty {
+  color: var(--text-muted-color, #64748b);
+  font-size: 0.88rem;
+  text-align: center;
 }
 
-.lighterpack-table-wrap {
-  overflow-x: auto;
+.lighterpack-col-weight {
+  flex: 0 0 110px;
+}
+
+.lighterpack-col-qty {
+  flex: 0 0 60px;
 }
 
 .lighterpack-item-name {
+  flex: 1 1 150px;
+  min-width: 50px;
   font-weight: 600;
+  margin-right: 4px;
 }
 
 .lighterpack-item-description {
-  margin-top: 0.15rem;
+  flex: 2 0 200px;
+  min-width: 100px;
+  margin-right: 4px;
   color: var(--text-muted-color, #64748b);
   font-size: 0.94rem;
 }
 
+.lighterpack-item-actions {
+  flex: 0 0 75px;
+  text-align: right;
+  padding: 0 0.5rem;
+}
+
+.lighterpack-icon {
+  font-style: normal;
+  margin-right: 4px;
+  font-size: 0.85rem;
+}
+
+.lighterpack-item-weight {
+  flex: 0 0 110px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.lighterpack-item-qty {
+  flex: 0 0 60px;
+  text-align: center;
+}
+
+.lighterpack-subtotal-weight {
+  flex: 0 0 110px;
+  text-align: right;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.lighterpack-subtotal-qty {
+  flex: 0 0 60px;
+  text-align: center;
+  font-weight: 700;
+}
+
 @media (max-width: 768px) {
   .lighterpack-summary,
-  .lighterpack-category {
-    padding: 1.1rem;
+  .lighterpack-items-header,
+  .lighterpack-item,
+  .lighterpack-items-footer {
+    padding-left: 1.1rem;
+    padding-right: 1.1rem;
   }
 
   .lighterpack-chart-shell {
@@ -225,5 +285,52 @@ pre,
   .lighterpack-meta {
     flex-direction: column;
     gap: 0.25rem;
+  }
+
+  .lighterpack-item {
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: flex-end;
+  }
+
+  .lighterpack-item-name {
+    flex-basis: 90px;
+    order: 2;
+  }
+
+  .lighterpack-item-description {
+    flex-basis: calc(100% - 50px);
+    order: 98;
+  }
+
+  .lighterpack-item-actions {
+    flex: 0 0 auto;
+    order: 99;
+    padding: 0 0.5rem;
+  }
+
+  .lighterpack-item-weight {
+    flex-basis: 100px;
+    order: 5;
+  }
+
+  .lighterpack-item-qty {
+    flex-basis: auto;
+    order: 1;
+  }
+
+  .lighterpack-item-qty[data-qty="1"] {
+    display: none;
+  }
+
+  .lighterpack-items-header {
+    .lighterpack-col-weight,
+    .lighterpack-col-qty {
+      display: none;
+    }
+  }
+
+  .lighterpack-items-footer .lighterpack-subtotal-qty {
+    display: none;
   }
 }

--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -374,11 +374,9 @@ pre,
     text-align: right;
   }
 
-  .lighterpack-items-header {
-    .lighterpack-col-weight,
-    .lighterpack-col-qty {
-      display: none;
-    }
+  .lighterpack-items-header .lighterpack-col-weight,
+  .lighterpack-items-header .lighterpack-col-qty {
+    display: none;
   }
 
   .lighterpack-items-footer .lighterpack-subtotal-qty {

--- a/tools/lighterpack-post-template.md
+++ b/tools/lighterpack-post-template.md
@@ -23,6 +23,5 @@ tags: [trail-running, gear, Wutai]
    - 自动把新装备追加到 `_data/gear.yml`（已有装备按名称匹配复用）。
    - 生成引用格式的 `_data/lighterpack/abc123.yml`。
 3. 复制这份模板到 `_posts/YYYY-MM-DD-your-slug.md`，把标题、日期、permalink、tags 和 `PACK_ID` 替换掉。
-4. 如果需要旧的自包含格式，加 `--inline` 参数：`ruby tools/lighterpack_sync.rb --inline https://lighterpack.com/r/abc123`。
 
 装备在不同活动中共享，可以在 [Gear](/gear/) 页面查看每件装备的使用记录。

--- a/tools/lighterpack-post-template.md
+++ b/tools/lighterpack-post-template.md
@@ -10,18 +10,19 @@ tags: [trail-running, gear, Wutai]
 
 原始页面：[LighterPack - TITLE](https://lighterpack.com/r/PACK_ID)
 
-> 下面这块不走第三方 script。数据先抓到仓库里的 `_data/lighterpack/PACK_ID.yml`，再由本地模板渲染成静态 HTML，所以部署后仍然是纯静态页面，但版式会尽量贴近 LighterPack。
+> 下面这块不走第三方 script。数据先抓到仓库里的 `_data/lighterpack/PACK_ID.yml`，再由本地模板渲染成静态 HTML，所以部署后仍然是纯静态页面，但版式会尽量贴近 LighterPack。装备信息统一维护在 `_data/gear.yml`，各活动通过引用复用。
 
 {% include lighterpack.html id="PACK_ID" show_title="false" %}
-
-如果后面要同步新版清单，直接执行：`ruby tools/lighterpack_sync.rb https://lighterpack.com/r/PACK_ID`。省略 output 时，会默认写到 `_data/lighterpack/PACK_ID.yml`。
 
 ---
 
 使用步骤：
 
 1. 先在 LighterPack 建好新清单，拿到分享链接，例如 `https://lighterpack.com/r/abc123`。
-2. 执行：`ruby tools/lighterpack_sync.rb https://lighterpack.com/r/abc123`。这会默认生成 `_data/lighterpack/abc123.yml`。
+2. 执行：`ruby tools/lighterpack_sync.rb https://lighterpack.com/r/abc123`。这会：
+   - 自动把新装备追加到 `_data/gear.yml`（已有装备按名称匹配复用）。
+   - 生成引用格式的 `_data/lighterpack/abc123.yml`。
 3. 复制这份模板到 `_posts/YYYY-MM-DD-your-slug.md`，把标题、日期、permalink、tags 和 `PACK_ID` 替换掉。
+4. 如果需要旧的自包含格式，加 `--inline` 参数：`ruby tools/lighterpack_sync.rb --inline https://lighterpack.com/r/abc123`。
 
-如果和旧比赛有重复装备，不需要在仓库里做额外去重。LighterPack 那边怎么组织这次清单，这里就按这次快照渲染；不同比赛各自对应一个 YAML 文件。
+装备在不同活动中共享，可以在 [Gear](/gear/) 页面查看每件装备的使用记录。

--- a/tools/lighterpack_sync.rb
+++ b/tools/lighterpack_sync.rb
@@ -150,12 +150,20 @@ class LighterpackSync
     mg = extract_required(block, /<input type="hidden" class="lpMG" value="(\d+)"/, "item mg").to_i
     quantity = extract_required(block, %r{<span class="lpQtyCell lpNumber"[^>]*>\s*(.*?)\s*</span>}m, "item quantity").to_i
 
-    {
+    worn = block.include?("lpWorn lpActive") || block.include?("lpWorn\" lpActive")
+    consumable = block.include?("lpConsumable lpActive") || block.include?("lpConsumable\" lpActive")
+    star = block.match?(/lpStar[123]/)
+
+    item = {
       "name" => name,
       "description" => description,
       "weight" => weight_hash(mg, value, unit),
       "quantity" => quantity
     }
+    item["worn"] = true if worn
+    item["consumable"] = true if consumable
+    item["star"] = true if star
+    item
   end
 
   def parse_total(html, categories)

--- a/tools/lighterpack_sync.rb
+++ b/tools/lighterpack_sync.rb
@@ -354,7 +354,8 @@ class LighterpackSync
   end
 
   def deep_dup(obj)
-    Marshal.load(Marshal.dump(obj))
+    require "json"
+    JSON.parse(JSON.generate(obj))
   end
 end
 

--- a/tools/lighterpack_sync.rb
+++ b/tools/lighterpack_sync.rb
@@ -10,21 +10,25 @@ require "yaml"
 
 class LighterpackSync
   DEFAULT_OUTPUT_DIR = File.expand_path("../_data/lighterpack", __dir__)
+  DEFAULT_GEAR_PATH  = File.expand_path("../_data/gear.yml", __dir__)
 
-  def initialize(pack_ref, output_path = nil)
+  def initialize(pack_ref, output_path = nil, inline: false)
     @pack_id = normalize_pack_id(pack_ref)
     @source_url = URI("https://lighterpack.com/r/#{@pack_id}")
     @output_path = output_path || File.join(DEFAULT_OUTPUT_DIR, "#{@pack_id}.yml")
+    @inline = inline
+    @gear_path = DEFAULT_GEAR_PATH
   end
 
   def run
     html = fetch_html
     pack = parse_pack(html)
-    FileUtils.mkdir_p(File.dirname(@output_path))
-    File.open(@output_path, "w:UTF-8") do |file|
-      file.write(YAML.dump(pack))
+
+    if @inline
+      write_inline(pack)
+    else
+      write_with_gear_catalog(pack)
     end
-    puts "Wrote #{@output_path}"
   end
 
   private
@@ -242,10 +246,136 @@ class LighterpackSync
   def format_percent(number)
     format("%.2f", number).sub(/\.0+\z/, "").sub(/(\.\d*[1-9])0+\z/, '\\1')
   end
+
+  # --- Inline mode (legacy): writes a single self-contained YAML ----------
+
+  def write_inline(pack)
+    FileUtils.mkdir_p(File.dirname(@output_path))
+    File.open(@output_path, "w:UTF-8") do |file|
+      file.write(YAML.dump(pack))
+    end
+    puts "Wrote #{@output_path} (inline mode)"
+  end
+
+  # --- Gear-catalog mode: updates _data/gear.yml and writes ref-based pack -
+
+  def write_with_gear_catalog(pack)
+    gear_catalog = load_gear_catalog
+    ref_pack = deep_dup(pack)
+
+    ref_pack["categories"].each do |category|
+      category["items"] = category["items"].map do |item|
+        slug = find_or_create_gear(gear_catalog, item, category["name"])
+        ref_item = { "gear" => slug, "quantity" => item["quantity"] }
+        ref_item["worn"] = true if item["worn"]
+        ref_item["consumable"] = true if item["consumable"]
+        ref_item["star"] = true if item["star"]
+        ref_item
+      end
+    end
+
+    save_gear_catalog(gear_catalog)
+    FileUtils.mkdir_p(File.dirname(@output_path))
+    File.open(@output_path, "w:UTF-8") do |file|
+      file.write(YAML.dump(ref_pack))
+    end
+
+    puts "Wrote #{@gear_path}"
+    puts "Wrote #{@output_path}"
+  end
+
+  def load_gear_catalog
+    return {} unless File.exist?(@gear_path)
+
+    YAML.safe_load(File.read(@gear_path, encoding: "UTF-8")) || {}
+  end
+
+  def save_gear_catalog(catalog)
+    FileUtils.mkdir_p(File.dirname(@gear_path))
+    File.open(@gear_path, "w:UTF-8") do |file|
+      file.write(YAML.dump(catalog))
+    end
+  end
+
+  def find_or_create_gear(catalog, item, category_name)
+    name = item["name"]
+    description = item["description"].to_s
+
+    # Try to find existing entry by name match
+    existing = catalog.find { |_slug, entry| entry["name"] == name }
+    return existing[0] if existing
+
+    # Create new entry
+    slug = generate_slug(name, description)
+    slug = deduplicate_slug(catalog, slug)
+
+    entry = { "name" => name, "weight_mg" => item.dig("weight", "mg"), "description" => description }
+
+    brand = extract_brand(description, name)
+    entry["brand"] = brand if brand
+
+    entry["category_hint"] = category_name
+
+    catalog[slug] = entry
+    slug
+  end
+
+  def generate_slug(name, description)
+    brand = extract_brand(description, name)
+    base = brand ? "#{brand}-#{name}" : name
+    base.downcase
+      .gsub(/[^a-z0-9\s-]/, "")
+      .gsub(/\s+/, "-")
+      .gsub(/-+/, "-")
+      .gsub(/\A-|-\z/, "")
+      .slice(0, 60)
+  end
+
+  def extract_brand(description, _name)
+    # Try to pick a brand from the first word of description if it looks like one
+    return nil if description.nil? || description.empty?
+
+    first_token = description.split(/[\s;,]/).first
+    return nil unless first_token && first_token.match?(/\A[A-Za-z]/)
+
+    first_token
+  end
+
+  def deduplicate_slug(catalog, slug)
+    return slug unless catalog.key?(slug)
+
+    counter = 2
+    loop do
+      candidate = "#{slug}-#{counter}"
+      return candidate unless catalog.key?(candidate)
+
+      counter += 1
+    end
+  end
+
+  def deep_dup(obj)
+    Marshal.load(Marshal.dump(obj))
+  end
 end
+
+require "optparse"
+
+options = { inline: false }
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby tools/lighterpack_sync.rb [options] PACK_ID_OR_URL [OUTPUT_PATH]"
+
+  opts.on("--inline", "Write self-contained YAML without gear catalog (legacy mode)") do
+    options[:inline] = true
+  end
+
+  opts.on("-h", "--help", "Print this help") do
+    puts opts
+    exit
+  end
+end.parse!
 
 if ARGV.empty?
-  abort("Usage: ruby tools/lighterpack_sync.rb PACK_ID_OR_URL [OUTPUT_PATH]")
+  abort("Usage: ruby tools/lighterpack_sync.rb [--inline] PACK_ID_OR_URL [OUTPUT_PATH]")
 end
 
-LighterpackSync.new(ARGV[0], ARGV[1]).run
+LighterpackSync.new(ARGV[0], ARGV[1], inline: options[:inline]).run

--- a/tools/lighterpack_sync.rb
+++ b/tools/lighterpack_sync.rb
@@ -12,23 +12,17 @@ class LighterpackSync
   DEFAULT_OUTPUT_DIR = File.expand_path("../_data/lighterpack", __dir__)
   DEFAULT_GEAR_PATH  = File.expand_path("../_data/gear.yml", __dir__)
 
-  def initialize(pack_ref, output_path = nil, inline: false)
+  def initialize(pack_ref, output_path = nil)
     @pack_id = normalize_pack_id(pack_ref)
     @source_url = URI("https://lighterpack.com/r/#{@pack_id}")
     @output_path = output_path || File.join(DEFAULT_OUTPUT_DIR, "#{@pack_id}.yml")
-    @inline = inline
     @gear_path = DEFAULT_GEAR_PATH
   end
 
   def run
     html = fetch_html
     pack = parse_pack(html)
-
-    if @inline
-      write_inline(pack)
-    else
-      write_with_gear_catalog(pack)
-    end
+    write_with_gear_catalog(pack)
   end
 
   private
@@ -247,16 +241,6 @@ class LighterpackSync
     format("%.2f", number).sub(/\.0+\z/, "").sub(/(\.\d*[1-9])0+\z/, '\\1')
   end
 
-  # --- Inline mode (legacy): writes a single self-contained YAML ----------
-
-  def write_inline(pack)
-    FileUtils.mkdir_p(File.dirname(@output_path))
-    File.open(@output_path, "w:UTF-8") do |file|
-      file.write(YAML.dump(pack))
-    end
-    puts "Wrote #{@output_path} (inline mode)"
-  end
-
   # --- Gear-catalog mode: updates _data/gear.yml and writes ref-based pack -
 
   def write_with_gear_catalog(pack)
@@ -359,24 +343,8 @@ class LighterpackSync
   end
 end
 
-require "optparse"
-
-options = { inline: false }
-OptionParser.new do |opts|
-  opts.banner = "Usage: ruby tools/lighterpack_sync.rb [options] PACK_ID_OR_URL [OUTPUT_PATH]"
-
-  opts.on("--inline", "Write self-contained YAML without gear catalog (legacy mode)") do
-    options[:inline] = true
-  end
-
-  opts.on("-h", "--help", "Print this help") do
-    puts opts
-    exit
-  end
-end.parse!
-
 if ARGV.empty?
-  abort("Usage: ruby tools/lighterpack_sync.rb [--inline] PACK_ID_OR_URL [OUTPUT_PATH]")
+  abort("Usage: ruby tools/lighterpack_sync.rb PACK_ID_OR_URL [OUTPUT_PATH]")
 end
 
-LighterpackSync.new(ARGV[0], ARGV[1], inline: options[:inline]).run
+LighterpackSync.new(ARGV[0], ARGV[1]).run


### PR DESCRIPTION
LighterPack data was stored as self-contained per-activity snapshots, so gear items were fully duplicated across activities with no way to share or cross-reference them. This adds `_data/gear.yml` as a single source of truth for all gear, with pack files referencing items by slug.

### Gear catalog (`_data/gear.yml`)

- Each item keyed by a unique slug (`fuga-air13`, `coros-vertix-2s`, etc.) with `name`, `brand`, `weight_mg`, `description`, `category_hint`
- 20 items extracted from the existing `4nz20u` pack

### Pack files now use references

Pack YAML items changed from inline data to slug references:

```yaml
# before
- name: Run Vest AIR 13
  description: FUGA AIR13; 高频口哨
  weight:
    mg: 230000
    grams: 230.0
    value: '230'
    unit: g
    display: 230 g
  quantity: 1

# after
- gear: fuga-air13
  quantity: 1
```

### Template resolution (`_includes/lighterpack.html`)

- Resolves `item.gear` → `site.data.gear[item.gear]` at render time
- Pack-level overrides (`description`, `weight`) take precedence when present

### Sync script (`tools/lighterpack_sync.rb`)

- On sync, matches parsed items against existing gear catalog by name; creates new entries for unknowns
- Always outputs reference format (no inline mode)

### Gear overview page (`_tabs/gear.md`)

- Lists all gear with reverse index: for each item, shows which activities used it via `_includes/gear_usage.html`